### PR TITLE
Fixed status code change for Transactional controllers

### DIFF
--- a/EventListener/TransactionalListener.php
+++ b/EventListener/TransactionalListener.php
@@ -160,7 +160,6 @@ class TransactionalListener implements EventSubscriberInterface
             $view->setData(
                 $this->transactionResponseManager->handle($transaction, $data, $violations)
             );
-            $view->setStatusCode($transaction->getStatus());
         }
     }
 


### PR DESCRIPTION
When Controller is set as Transactional - @EcentriaAnnotation\Transactional, then we where replacing specified response code in Controller with status provided by Transaction Listener. In most cases it was 201.
