### PR TITLE
[Validators] In array validator improvement.

### DIFF
--- a/Validator/Constraints/InArrayValidator.php
+++ b/Validator/Constraints/InArrayValidator.php
@@ -28,7 +28,7 @@ class InArrayValidator extends ConstraintValidator
         if (!$constraint instanceof InArray) {
             throw new \Exception('This constraint must be instance of EcentriaRestBundle:InArray');
         }
-        if (!in_array($value, $constraint->values)) {
+        if (!in_array($value, $constraint->values, true)) {
             $this->context->addViolation(
                 sprintf(
                     "Value '%s' is not supported. Possible values: \"'%s'\"",


### PR DESCRIPTION
Without strict flag $result will be true, instead of false.

$value = true;
$result = in_array($value, ['a', 'b']);
