### PR TITLE
Exposed ping and status urls

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -11,7 +11,11 @@ transaction-service:
 status:
     type:     rest
     resource: Ecentria\Libraries\EcentriaRestBundle\Controller\StatusController
+    options:
+        expose: true
 
 ping:
     type:     rest
     resource: Ecentria\Libraries\EcentriaRestBundle\Controller\PingController
+    options:
+        expose: true


### PR DESCRIPTION
Exposed ping and status urls.
They are available in /api/configuration response

```
{
  "routes": {
    ...
    "get_status": {
      "method": "GET",
      "pattern": "/status.{_format}"
    },
    "get_ping": {
      "method": "GET",
      "pattern": "/ping.{_format}"
    },
    ...
  }
}
```
