### PR TITLE
Change log level Error to Warning when Transaction::CONFLICT…

### DIFF
--- a/Services/Transaction/Storage/Monolog.php
+++ b/Services/Transaction/Storage/Monolog.php
@@ -93,7 +93,7 @@ class Monolog implements TransactionStorageInterface {
             }
 
             if (
-                ($this->log404AsWarning && $transaction->getStatus() === 404) ||
+                ($this->log404AsWarning && $transaction->getStatus() === Transaction::STATUS_NOT_FOUND) ||
                 $transaction->getStatus() === Transaction::STATUS_CONFLICT
             ) {
                 $level = Logger::WARNING;

--- a/Services/Transaction/Storage/Monolog.php
+++ b/Services/Transaction/Storage/Monolog.php
@@ -10,6 +10,7 @@
 
 namespace Ecentria\Libraries\EcentriaRestBundle\Services\Transaction\Storage;
 
+use Ecentria\Libraries\ApiClientBundle\Model\Transaction;
 use Ecentria\Libraries\EcentriaRestBundle\Model\Transaction as TransactionModel;
 use JMS\Serializer\Serializer;
 use Monolog\Logger;
@@ -90,9 +91,14 @@ class Monolog implements TransactionStorageInterface {
                 }
                 $level = $value;
             }
-            if ($this->log404AsWarning && $transaction->getStatus() === 404) {
+
+            if (
+                ($this->log404AsWarning && $transaction->getStatus() === 404) ||
+                $transaction->getStatus() === Transaction::STATUS_CONFLICT
+            ) {
                 $level = Logger::WARNING;
             }
+
             $errorMessage = '';
             if (isset($transaction->getMessages()['errors'])) {
                 foreach ($transaction->getMessages()['errors'] as $error) {

--- a/Services/Transaction/Storage/Monolog.php
+++ b/Services/Transaction/Storage/Monolog.php
@@ -10,7 +10,6 @@
 
 namespace Ecentria\Libraries\EcentriaRestBundle\Services\Transaction\Storage;
 
-use Ecentria\Libraries\ApiClientBundle\Model\Transaction;
 use Ecentria\Libraries\EcentriaRestBundle\Model\Transaction as TransactionModel;
 use JMS\Serializer\Serializer;
 use Monolog\Logger;
@@ -93,8 +92,8 @@ class Monolog implements TransactionStorageInterface {
             }
 
             if (
-                ($this->log404AsWarning && $transaction->getStatus() === Transaction::STATUS_NOT_FOUND) ||
-                $transaction->getStatus() === Transaction::STATUS_CONFLICT
+                ($this->log404AsWarning && $transaction->getStatus() === TransactionModel::STATUS_NOT_FOUND) ||
+                $transaction->getStatus() === TransactionModel::STATUS_CONFLICT
             ) {
                 $level = Logger::WARNING;
             }


### PR DESCRIPTION
Conflict cases are just validation's errors, not the system's. So, I guess, it's gonna be `WARNING` level, instead of `ERROR`.