### PR TITLE
Change log level for transaction conflict / Replace value by Constant

### DIFF
--- a/Services/Transaction/Storage/Monolog.php
+++ b/Services/Transaction/Storage/Monolog.php
@@ -90,9 +90,14 @@ class Monolog implements TransactionStorageInterface {
                 }
                 $level = $value;
             }
-            if ($this->log404AsWarning && $transaction->getStatus() === 404) {
+
+            if (
+                ($this->log404AsWarning && $transaction->getStatus() === TransactionModel::STATUS_NOT_FOUND) ||
+                $transaction->getStatus() === TransactionModel::STATUS_CONFLICT
+            ) {
                 $level = Logger::WARNING;
             }
+
             $errorMessage = '';
             if (isset($transaction->getMessages()['errors'])) {
                 foreach ($transaction->getMessages()['errors'] as $error) {


### PR DESCRIPTION
Conflict's cases are just validation's errors, not the system's. So, I guess, it's gonna be `WARNING` level, instead of `ERROR`.